### PR TITLE
feat: improve SDK consistency and add bulk operations

### DIFF
--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
-import { ok, err } from 'neverthrow';
+import { err, ok } from 'neverthrow';
 import { ValidationError } from '@/lib/error-handler';
 import createLightfastComputer from '@/sdk';
 import * as commandService from '@/services/command-service';


### PR DESCRIPTION
## Summary
- Fixed inconsistent return types by making `list()` and `getStats()` return Result types
- Added bulk operations: `stopAll()` and `destroyAll()` convenience methods
- Extracted repetitive validation code to helper function
- Added comprehensive TypeScript type exports

## Changes
- **Consistent Return Types**: `instances.list()` and `instances.getStats()` now return `Result<T, E>` instead of direct values
- **Bulk Operations**: Added `instances.stopAll()` and `instances.destroyAll()` for managing multiple instances
- **Code Quality**: Extracted `validateInstanceId()` helper to reduce repetitive validation code  
- **Type Safety**: Exported `InstanceStats` interface for better TypeScript integration
- **Comprehensive Tests**: Added full test coverage for all new functionality

## Breaking Changes
- `instances.list()` now returns `Result<Instance[], AppError>` instead of `Promise<Instance[]>`
- `instances.getStats()` now returns `Result<InstanceStats, AppError>` instead of `Promise<InstanceStats>`

## Migration Guide
```typescript
// Before
const instances = await computer.instances.list();
const stats = await computer.instances.getStats();

// After  
const instancesResult = await computer.instances.list();
if (instancesResult.isOk()) {
  const instances = instancesResult.value;
}

const statsResult = await computer.instances.getStats();
if (statsResult.isOk()) {
  const stats = statsResult.value;
}
```

## Test Plan
- [x] All new bulk operations tests pass (`stopAll`, `destroyAll`)
- [x] Consistent Result type handling across all methods
- [x] Helper function validation works correctly
- [x] TypeScript builds cleanly (`bun run build`)
- [x] Core SDK functionality maintains compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)