### PR TITLE
fix: suppress pino logger output during test execution

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,16 @@
+import pino from 'pino';
+
+// Detect if we're running in a test environment
+// Check multiple indicators since different test runners set different vars
+const isTestEnvironment =
+  process.env.NODE_ENV === 'test' || process.argv.some((arg) => arg.includes('.test.') || arg.includes('/tests/'));
+
+// Create logger with appropriate configuration
+export const createLogger = () => {
+  return pino({
+    level: isTestEnvironment ? 'silent' : process.env.LOG_LEVEL || 'info',
+  });
+};
+
+// Export a default logger instance
+export const logger = createLogger();

--- a/src/services/command-service.ts
+++ b/src/services/command-service.ts
@@ -1,9 +1,9 @@
 import { spawn } from 'node:child_process';
 import { err, ok, type Result } from 'neverthrow';
-import pino from 'pino';
 import { type InfrastructureError, InstanceOperationError } from '@/lib/error-handler';
+import { createLogger } from '@/lib/logger';
 
-const log = pino();
+const log = createLogger();
 
 // Types
 export interface CommandExecution {

--- a/src/services/fly-service.ts
+++ b/src/services/fly-service.ts
@@ -1,9 +1,9 @@
 import { err, ok, type Result } from 'neverthrow';
-import pino from 'pino';
 import { InfrastructureError, InstanceCreationError, InstanceOperationError } from '@/lib/error-handler';
+import { createLogger } from '@/lib/logger';
 import type { CreateInstanceOptions } from '@/types/index';
 
-const log = pino();
+const log = createLogger();
 
 interface FlyMachine {
   id: string;

--- a/src/services/instance-service.ts
+++ b/src/services/instance-service.ts
@@ -1,10 +1,10 @@
 import { err, ok, type Result } from 'neverthrow';
-import pino from 'pino';
 import { AppError, NotFoundError } from '@/lib/error-handler';
+import { createLogger } from '@/lib/logger';
 import * as flyService from '@/services/fly-service';
 import type { CreateInstanceOptions, FlyRegion, Instance, InstanceStatus, MachineSize } from '@/types/index';
 
-const log = pino();
+const log = createLogger();
 
 // Create instance with GitHub integration
 export const createInstanceWithGitHub = async (

--- a/tests/lib/logger.test.ts
+++ b/tests/lib/logger.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, spyOn } from 'bun:test';
+import { createLogger } from '@/lib/logger';
+
+describe('logger configuration', () => {
+  it('should detect test environment', () => {
+    // When running tests, process.argv should contain test file paths
+    const hasTestFile = process.argv.some((arg) => arg.includes('.test.') || arg.includes('/tests/'));
+    expect(hasTestFile).toBe(true);
+  });
+
+  it('should be silent during tests', () => {
+    // Create a logger instance using our factory
+    const logger = createLogger();
+
+    // In test environment, logger should be silent
+    expect(logger.level).toBe('silent');
+  });
+
+  it('should not output logs during test execution', () => {
+    // Spy on process.stdout.write since pino writes directly to stdout
+    const stdoutSpy = spyOn(process.stdout, 'write');
+
+    // Create logger and try to log
+    const logger = createLogger();
+    logger.info('This should not appear');
+    logger.error('This should not appear');
+    logger.warn('This should not appear');
+
+    // Verify no stdout output (pino writes to stdout, not console)
+    expect(stdoutSpy).not.toHaveBeenCalled();
+
+    // Restore spy
+    stdoutSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed issue where pino logger was outputting error logs during test execution
- Tests now run cleanly without any logger output

## Changes
- Created `src/lib/logger.ts` with test environment detection
- Updated all services to use centralized `createLogger()` function
- Added comprehensive tests for logger configuration
- Logger automatically sets level to 'silent' when running tests

## Test Plan
- [x] All tests pass (`bun test`)
- [x] TypeScript builds cleanly (`bun run build`)
- [x] Linting passes (`bun run lint`)
- [x] Verified no logger output during test runs

🤖 Generated with [Claude Code](https://claude.ai/code)